### PR TITLE
updated selenium from 3.13.0 (Jun 25, 2018) to 3.141.59 (Nov 14, 2018)

### DIFF
--- a/pom-tests.xml
+++ b/pom-tests.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.jboss.arquillian.selenium</groupId>
   <artifactId>selenium-bom-tests</artifactId>
-  <version>3.13.0</version>
+  <version>3.141.59</version>
   <packaging>pom</packaging>
 
   <name>Selenium BOM Test</name>
@@ -31,7 +31,6 @@
       <email>mjobanek@redhat.com</email>
     </developer>
   </developers>
-
 
   <dependencyManagement>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.jboss.arquillian.selenium</groupId>
   <artifactId>selenium-bom</artifactId>
-  <version>3.13.0</version>
+  <version>3.141.59</version>
   <packaging>pom</packaging>
 
   <name>Arquillian Selenium Dependency Management</name>


### PR DESCRIPTION
#### Short description of what this resolves:
Selenium 3.13.0 is too old. Need newest version. Working on a Migration to Jakarta EE (8).

#### Changes proposed in this pull request:
- updated selenium from 3.13.0 (Jun 25, 2018) to 3.141.59 (Nov 14, 2018)

**Fixes**: #27
